### PR TITLE
Add TypeScript checking via JSDoc type annotations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.DS_Store
 output/
 node_modules/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "js/ts.implicitProjectConfig.checkJs": true,
+  "typescript.preferences.importModuleSpecifier": "relative",
+  "typescript.preferences.importModuleSpecifierEnding": "auto",
+  "typescript.preferences.quoteStyle": "single",
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "typescript.enablePromptUseWorkspaceTsdk": true,
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,10 @@
 {
-  "name": "website-wrapper-app",
+  "name": "outline-app-maker",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "name": "outline-app-maker",
       "license": "Apache-2.0",
       "dependencies": {
         "@ngrok/ngrok": "1.4.1",
@@ -15,9 +16,12 @@
         "yaml": "^2.7.1"
       },
       "devDependencies": {
+        "@types/archiver": "^6.0.3",
+        "@types/minimist": "^1.2.5",
         "glob": "^11.0.1",
         "handlebars": "^4.7.8",
-        "vite": "^6.2.7"
+        "typescript": "^5.8.3",
+        "vite": "^6.2.0"
       }
     },
     "navigation_proxy": {
@@ -920,21 +924,46 @@
         "win32"
       ]
     },
+    "node_modules/@types/archiver": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-6.0.3.tgz",
+      "integrity": "sha512-a6wUll6k3zX6qs5KlxIggs1P1JcYJaTCx2gnlr+f0S1yd2DoaEwoIK10HmBaLnZwWneBz+JBm0dwcZu0zECBcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/readdir-glob": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
       "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
       "dev": true
     },
+    "node_modules/@types/minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.13.10",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
       "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.20.0"
+      }
+    },
+    "node_modules/@types/readdir-glob": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@types/readdir-glob/-/readdir-glob-1.1.5.tgz",
+      "integrity": "sha512-raiuEPUYqXu+nvtY2Pe8s8FEmZ3x5yAH4VkLdihcPdalvsHltomrRC9BzuStrJ9yk06470hS0Crw0f1pXqD+Hg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/abort-controller": {
@@ -1112,10 +1141,9 @@
       ]
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "license": "MIT",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -1848,10 +1876,9 @@
       }
     },
     "node_modules/serve-handler/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "license": "MIT",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -2042,6 +2069,20 @@
         "b4a": "^1.6.4"
       }
     },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/uglify-js": {
       "version": "3.19.3",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
@@ -2059,9 +2100,7 @@
       "version": "6.20.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
       "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
@@ -2069,11 +2108,10 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/vite": {
-      "version": "6.2.7",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.7.tgz",
-      "integrity": "sha512-qg3LkeuinTrZoJHHF94coSaTfIPyBYoywp+ys4qu20oSJFbKMYoIJo0FWJT9q6Vp49l6z9IsJRbHdcGtiKbGoQ==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.2.tgz",
+      "integrity": "sha512-yW7PeMM+LkDzc7CgJuRLMW2Jz0FxMOsVJ8Lv3gpgW9WLcb9cTW+121UEr1hvmfR7w3SegR5ItvYyzVz1vxNJgQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
         "postcss": "^8.5.3",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "outline-app-maker",
   "dependencies": {
     "@ngrok/ngrok": "1.4.1",
     "archiver": "^7.0.1",
@@ -9,9 +10,12 @@
     "yaml": "^2.7.1"
   },
   "devDependencies": {
+    "@types/archiver": "^6.0.3",
+    "@types/minimist": "^1.2.5",
     "glob": "^11.0.1",
     "handlebars": "^4.7.8",
-    "vite": "^6.2.7"
+    "typescript": "^5.8.3",
+    "vite": "^6.2.0"
   },
   "license": "Apache-2.0",
   "scripts": {
@@ -20,7 +24,8 @@
     "clean": "npx rimraf node_modules/ output/",
     "doctor": "./doctor",
     "reset": "npm run clean && npm ci",
-    "start:navigator": "node ./basic_navigator_example/.scripts/start.mjs"
+    "start:navigator": "node ./basic_navigator_example/.scripts/start.mjs",
+    "typescript:check": "tsc --noEmit"
   },
   "private": true
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+    "module": "node16",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "**/*.cjs",
+    "**/*.mjs",
+    "**/*.js",
+    "**/.*/**/*.cjs",
+    "**/.*/**/*.mjs",
+    "**/.*/**/*.js",
+  ],
+  "exclude": [
+    "basic_navigator_example", // TODO: Remove this exclusion?
+    "node_modules",
+  ]
+}

--- a/wrapper_app_project/.scripts/config.mjs
+++ b/wrapper_app_project/.scripts/config.mjs
@@ -22,20 +22,37 @@ export const DEFAULT_CONFIG = {
   })
 }
 
+/**
+ * @param {string} filepath
+ * @returns {Promise<{}>}
+ */
 export async function getYAMLFileConfig(filepath) {
   try {
     const data = await fs.readFile(filepath, 'utf8')
     
     if (data) {
-      return YAML.parse(data)
+      const parsedData = YAML.parse(data);
+
+      if (parsedData && typeof parsedData === 'object' && !Array.isArray(parsedData)) {
+        // This type assertion may not be 100% guaranteed but for the purposes
+        // of this use case should be correct
+        return /** @type {{}} */ (parsedData);
+      } else {
+        console.warn(`${filepath} contained invalid config data:`, parsedData)
+      }
+    } else {
+      console.warn(`${filepath} contained no data`)
     }
   } catch (e) {
-    if ('ENOENT' == e.code) {
-      return {}
-    }
+    console.warn(`Error loading ${filepath}:`, e)
   }
+
+  return {};
 }
 
+/**
+ * @param {NodeJS.Process["argv"]} args
+ */
 export function getCliConfig(args) {
   const dict = minimist(args)
   return {

--- a/wrapper_app_project/.scripts/types.mjs
+++ b/wrapper_app_project/.scripts/types.mjs
@@ -1,0 +1,13 @@
+
+/**
+ * @typedef {{
+ *   additionalDomains: Array<string>;
+ *   appId: string;
+ *   appName: string;
+ *   domainList: string;
+ *   entryDomain: string;
+ *   output: string;
+ *   platform: string;
+ *   smartDialerConfig: string;
+ * }} Config
+ */


### PR DESCRIPTION
Note: I’ve copied this as-is from https://github.com/Jigsaw-Code/outline-sdk/pull/473 but currently the `build` script fails due to unrelated issues (will investigate further and open an issue/PR).

---

(Let me know if this is something you’re interested in at all -- I like having type safety for the project but I know TypeScript imposes some additional burden on contributors and maintainers.)

I started this because while working on Jigsaw-Code#472 I noticed getYAMLFileConfig had some additional edge cases where undefined could get returned, but figured I could fully implement type safety in wrapper_app_project while I was at it.

Some notes:

* Adds a basic tsconfig.json with "strict" enabled, but type checking in basic_navigator_example disabled for now. You can run type checking with a new "typescript:check" script.

* Adds .vscode/settings.json to configure VS Code to do type checking and match the existing code style

* I’m not super familiar with the config format so I may be making some incorrect assumptions here.