### PR TITLE
(fix) Typo: additionalDomains

### DIFF
--- a/wrapper_app_project/.scripts/util.mjs
+++ b/wrapper_app_project/.scripts/util.mjs
@@ -39,7 +39,7 @@ export function resolveConfiguration(config) {
       .join(' ')
   }
   
-  resolved.additionalDomains = config.additionaldomain ?? []
+  resolved.additionalDomains = config.additionalDomains ?? []
   resolved.domainList = [resolved.entryDomain, ...resolved.additionalDomains].join('\n')
   resolved.smartDialerConfig = Buffer.from(JSON.stringify(config.smartDialerConfig)).toString('base64')
 


### PR DESCRIPTION
In the resulotion of the final configuration, additionalDomains was misspelled, effectively discarding its value.