### PR TITLE
Fix invalid xml in Android template project

### DIFF
--- a/wrapper_app_project/template/android/app/src/main/res/values/strings.xml.handlebars
+++ b/wrapper_app_project/template/android/app/src/main/res/values/strings.xml.handlebars
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <!-- 
     Copyright 2025 The Outline Authors
 
@@ -13,8 +14,6 @@
     See the License for the specific language governing permissions and
     limitations under the License.
  -->
-
-<?xml version='1.0' encoding='utf-8'?>
 <resources>
     <string name="app_name">{{appName}}</string>
     <string name="title_activity_main">{{appName}}</string>


### PR DESCRIPTION
- `wrapper_app_project/template/android/app/src/main/res/values/strings.xml.handlebars` 
  XML documents have to start with `<?xmx…`, I suppose, so I moved the comment down.